### PR TITLE
Resolve Issue #72: Fix movie paging

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
@@ -841,7 +841,7 @@ class AniListBrowser(BrowserBase):
         favourites = database.get(self.get_base_res, 24, variables)
         return self.process_anilist_view(favourites, "all_time_favourites?page=%d", page)
 
-    def get_top_100(self, page, format):
+    def get_top_100(self, page, format, plugin_url="top_100"):
         variables = {
             'page': page,
             'perpage': self.perpage,
@@ -868,7 +868,8 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         top_100 = database.get(self.get_base_res, 24, variables)
-        return self.process_anilist_view(top_100, "top_100?page=%d", page)
+        base_url = f"{plugin_url}?page=%d"
+        return self.process_anilist_view(top_100, base_url, page)
 
     def get_genre_action(self, page, format):
         variables = {

--- a/plugin.video.otaku.testing/resources/lib/Main.py
+++ b/plugin.video.otaku.testing/resources/lib/Main.py
@@ -694,7 +694,7 @@ def TOP_100(payload, params):
     format = None
     if plugin_url in mapping:
         format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
-    control.draw_items(BROWSER.get_top_100(page, format), 'tvshows')
+    control.draw_items(BROWSER.get_top_100(page, format, plugin_url), 'tvshows')
 
 
 @Route('genres/*')

--- a/plugin.video.otaku.testing/resources/lib/MalBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/MalBrowser.py
@@ -971,7 +971,7 @@ class MalBrowser(BrowserBase):
         favourites = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
         return self.process_mal_view(favourites, "all_time_favourites?page=%d", page)
 
-    def get_top_100(self, page, format):
+    def get_top_100(self, page, format, plugin_url="top_100"):
         params = {
             'page': page,
             'limit': self.perpage,
@@ -994,7 +994,8 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         top_100 = database.get(self.get_base_res, 24, f"{self._BASE_URL}/top/anime", params)
-        return self.process_mal_view(top_100, "top_100?page=%d", page)
+        base_url = f"{plugin_url}?page=%d"
+        return self.process_mal_view(top_100, base_url, page)
 
     def get_genre_action(self, page, format):
         params = {


### PR DESCRIPTION
## 🐛 Issue #72 : Movie Filter Lost When Paging Top 100

### Description

When browsing the **Top 100** movies list, the first page correctly shows only movies. However, the **“Next Page”** link uses the generic route `top_100?page=…`. When clicked, Kodi loads the default Top 100 list, mixing in TV shows instead of continuing the movie-only list.

---

### ✅ Fix

The pagination link now keeps the current route so the correct filter persists across pages.

---

### 🔑 Key Changes

**`AniListBrowser.get_top_100()`** and **`MalBrowser.get_top_100()`** were updated to accept a `plugin_url` argument and use it when building the “Next Page” URL:

```python
# AniListBrowser.py
def get_top_100(self, page, format, plugin_url="top_100"):
    ...
    base_url = f"{plugin_url}?page=%d"
    return self.process_anilist_view(top_100, base_url, page)

# MalBrowser.py
def get_top_100(self, page, format, plugin_url="top_100"):
    ...
    base_url = f"{plugin_url}?page=%d"
    return self.process_mal_view(top_100, base_url, page)
```

---

The `TOP_100` route now passes its own route name (`plugin_url`) when calling `BROWSER.get_top_100`:

```python
# routes.py
def TOP_100(payload, params):
    ...
    control.draw_items(BROWSER.get_top_100(page, format, plugin_url), 'tvshows')
```

---

### ✅ Result

With these adjustments, each pagination link retains the original route (e.g., `top_100_movie?page=2`), ensuring page 2 and beyond continue to show **only movies**.

---

# 📷 Screenshots  -- Before & After  + source list

---

# Source List - Top 30 (page 1 & 2)

<img width="1194" height="2077" alt="Image" src="https://github.com/user-attachments/assets/a34753e5-623b-4d73-a01d-97157981f78f" />

### Before: 

Branch - Main 

Otaku Testing - > Movies -> Top 100  (Page 1)

<img width="1555" height="1874" alt="Image" src="https://github.com/user-attachments/assets/a10a6240-dd4f-4030-b2a4-161e257e89ad" />


# Page #2 - Where the issue presents...  We now have a mix of shows and movies

<img width="2696" height="1919" alt="Image" src="https://github.com/user-attachments/assets/56811f1d-6776-484a-89bb-26e8324d8035" />


### After (Page 2): 

<img width="2673" height="2013" alt="Image" src="https://github.com/user-attachments/assets/05ec6dec-4d63-4a5e-a4ed-7df4e24a46ec" />

(Now correctly reflects the AniList top 100 ordering)