### PR TITLE
Fixes issue with skinvariables when creating widgets

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/ui/control.py
+++ b/plugin.video.otaku.testing/resources/lib/ui/control.py
@@ -719,7 +719,7 @@ def draw_items(video_data, content_type=''):
     elif content_type == 'tvshows':
         xbmcplugin.addSortMethod(HANDLE, xbmcplugin.SORT_METHOD_NONE, "%L", "%R")
     xbmcplugin.endOfDirectory(HANDLE, cacheToDisc=True)
-    closeAllDialogs()
+    #closeAllDialogs()
     if getBool('interface.viewtype'):
         xbmc.sleep(100)  # Delay so the directory is painted before changing view mode
         if getBool('interface.viewidswitch'):


### PR DESCRIPTION
## Issue Solved
Issue #146

## Problem

When creating a widget with skinvariables, otaku calls draw_items() to return the folder's contents. The problem is, it was calling closeAllDialogs(), which closed skinvariables's dialog and caused the mentioned bug

## Solution
the closeAllDialogs function was commented. Additionally, the addon was tested and used for a while to check for any unforeseen consequences.
For reference, I tested and had no issue with:
* adding an widget
* opening and closing the settings dialog
* opening and closing the airing anime calendar
* opening and closing the authentication dialogs for both anilist and torbox
* watching an episode normally
* searching for an anime
So, while I can't guarantee that there's no edge case where this might be an issue, I tried to minimize the chances

## Note

Thank you to the creator of skinshorcuts (I created an issue on the wrong add-on) for pointing what the issue was.
If you need any more info, please feel free